### PR TITLE
Clean up script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,16 +18,12 @@
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.1/css/all.css" integrity="sha384-50oBUHEmvpQ+1lW4y57PTFmhCaXp0ML5d60M1M7uH2+nqUivzIebhndOJK28anvf" crossorigin="anonymous">
 
   <!-- Plugin CSS -->
-  <link href="vendor/magnific-popup/magnific-popup.css" rel="stylesheet" type="text/css">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/magnific-popup.css" rel="stylesheet">
 
   <!-- Custom styles for this template -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/startbootstrap-freelancer/5.0.4/css/freelancer.css" rel="stylesheet">
   <link href="css/freelancerchanges.css" rel="stylesheet">
 
-  <!--JQuery -->
-  <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-  <!-- Moment.js CDN for parsing dates -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.js"></script>
 </head>
 
 <body id="page-top">
@@ -71,7 +67,7 @@
         </div>
       </div>
     </div>
-  </header> 
+  </header>
 
     <section id="connect" class="bg-second text-black text-center">
 
@@ -93,8 +89,6 @@
             </div>
           </div>
         </div>
-        <!-- Meetup API JS -->
-        <script src="openmaine.js"></script>
 
         <div class="col-md-6 col-lg-4">
           <div class="box">
@@ -110,8 +104,7 @@
           </div>
         </div>
       </div>
-      <!-- Meetup API JS -->
-      <script src="openmaine.js"></script>
+
       <br/>
       <br/>
       <div class="container">
@@ -237,19 +230,22 @@
   </div>
 
   <!-- Bootstrap core JavaScript -->
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 
   <!-- Plugin JavaScript -->
-
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.compatibility.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js"></script>
-
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.compatibility.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/jquery.magnific-popup.js"></script>
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/magnific-popup.js/1.1.0/magnific-popup.css" rel="stylesheet">
+
+  <!-- Moment.js for parsing dates -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.js"></script>
 
   <!-- Custom scripts for this template -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/startbootstrap-freelancer/5.0.4/js/freelancer.js"></script>
+
+  <!-- Meetup API JS -->
+  <script src="openmaine.js"></script>
 
 </body>
 

--- a/openmaine.js
+++ b/openmaine.js
@@ -8,7 +8,6 @@ function httpGet(theUrl) {
     },
     success: function(response) {
       var events = response.results;
-      console.log(events);
       var Portlandindex = -1;
       var Augustindex = -1;
       var i = 0;


### PR DESCRIPTION
There are a few JS errors because of scripts loading in the wrong
order.

Solution:

 - Move all script tags to the end (easier to see duplicates & load
   dependencies in the right order

 - Remove some duplicate script tags (e.g. there are two copies of jQuery)

Also:

 - Remove a link to local `magnific-popup.css` and replace with link
   to CDN

 - Remove a call to `console.log`.  I'm guessing this is here for debugging.