### PR TITLE
modifications to handle virtual meetups

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,8 +129,9 @@
             The next meetup in Portland is:
             <div id="day"></div>
             <div id="time"></div>
-            <div id="venue"></div>
-            <div id="location"></div>
+            <div>Online event</div>
+            <!--<div id="venue"></div>
+            <div id="location"></div> -->
             <a href="https://www.meetup.com/OpenMaine/" target="_blank">RSVP & view all events on Meetup</a>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -125,11 +125,11 @@
         <div class="box">
           <div class="box-img" style="background-image: url(https://upload.wikimedia.org/wikipedia/commons/6/69/Portland_Head_Lighthouse%2C_Maine.jpg)"></div>
           <div class="box-details">
-            The next meetup in Portland is:<br><br>
-						Virtual! Usually The third Thursday of the month.<br>
+            The next meetup in Portland is:<br> 
+						<!--Virtual! Usually The third Thursday of the month.<br> -->
             <div id="day"></div>
             <div id="time"></div>
-            <div>Online event</div>
+            <div>Online event</div> 
             <!--<div id="venue"></div>
             <div id="location"></div> -->
             <a href="https://www.meetup.com/OpenMaine/" target="_blank">RSVP & view all events on Meetup</a>
@@ -141,8 +141,8 @@
         <div class="box">
           <div class="box-img" style="background-image: url(https://upload.wikimedia.org/wikipedia/commons/c/c6/Maine_State_House_from_Capitol_Park.jpg)"></div>
           <div class="box-details">
-            The next meetup in Augusta is:<br><br>
-						Virtual! Usually The second Wednesday of the month.<br>
+            The next meetup in Augusta is:<br>
+						<!--Virtual! Usually The second Wednesday of the month.<br> -->
             <div id="Aday"></div>
             <div id="Atime"></div>
             <div id="Avenue"></div>

--- a/openmaine.js
+++ b/openmaine.js
@@ -6,6 +6,7 @@ function httpGet(theUrl) {
     data: {
       format: "json"
     },
+   
     success: function(response) {
       var events = response.results;
       var Portlandindex = -1;
@@ -15,7 +16,7 @@ function httpGet(theUrl) {
         if (events[i].venue != undefined) {
           if (events[i].venue.city === "Portland") {
             Portlandindex = i;
-          } else if (events[i].venue.city === "Augusta") {
+          } else if (events[i].name === "OpenMaine in Augusta Meetup: Civic Tech in Central Maine") {
             Augustindex = i;
           }
         }
@@ -29,8 +30,8 @@ function httpGet(theUrl) {
       var venue = events[Portlandindex].venue.name;
       var location = events[Portlandindex].venue.address_1;
       document.getElementById("day").innerHTML = date;
-      document.getElementById("venue").innerHTML = venue;
-      document.getElementById("location").innerHTML = location;
+      /*document.getElementById("venue").innerHTML = venue;
+      document.getElementById("location").innerHTML = location;*/
 
       var utcSeconds = events[Augustindex].time;
       var Ud = new Date(utcSeconds);
@@ -40,7 +41,7 @@ function httpGet(theUrl) {
       var Alocation = events[Augustindex].venue.address_1;
       document.getElementById("Aday").innerHTML = Adate;
       document.getElementById("Avenue").innerHTML = Avenue;
-      document.getElementById("Alocation").innerHTML = Alocation;
+      /*document.getElementById("Alocation").innerHTML = Alocation;*/
     }
   });
 }
@@ -48,3 +49,4 @@ function httpGet(theUrl) {
 var data = httpGet(
   "https://api.meetup.com/2/events?&sign=true&photo-host=public&group_urlname=OpenMaine&page=20&callback=?"
 );
+


### PR DESCRIPTION
-Modified js to pull name of event rather than location for Augusta meetings since those are now being added as being located online rather than in Augusta.  I commented out previous code so that it can be un-commented when Augusta goes back to in person meetings
-Modified html since Portland meetings are still being added to meetup with a physical location
-If changes are made to the information added to meetup for future meetings, changes to the js and html files will likely be needed