### PR TITLE
Update “Donate” page link

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
         </div>
         <div class=" container text-center mt-4">
           <p class="lead"> We welcome finanical contributions through Code for America.</p>
-          <a class="btn btn-xl btn-outline-dark text-dark" href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Open%20Maine" target="_blank">
+          <a class="btn btn-xl btn-outline-dark text-dark" href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Open%20Maine&utm_source=OpenMaine%20site" target="_blank">
           Donate Now!
         </a>
         </div>


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ